### PR TITLE
Capture subscriber

### DIFF
--- a/priv/repo/migrations/20170531015745_create_subscribers.exs
+++ b/priv/repo/migrations/20170531015745_create_subscribers.exs
@@ -1,0 +1,13 @@
+defmodule Gotv.Repo.Migrations.CreateSubscribers do
+  use Ecto.Migration
+
+  def change do
+    create table(:subscribers) do
+      add :first_name, :string
+      add :last_name, :string
+      add :email_address, :string
+
+      timestamps()
+    end
+  end
+end

--- a/test/controllers/page_controller_test.exs
+++ b/test/controllers/page_controller_test.exs
@@ -3,6 +3,6 @@ defmodule Gotv.PageControllerTest do
 
   test "GET /", %{conn: conn} do
     conn = get conn, "/"
-    assert html_response(conn, 200) =~ "Welcome to Phoenix!"
+    assert html_response(conn, 200) =~ "Get out the vote!"
   end
 end

--- a/test/controllers/subscriber_controller_test.exs
+++ b/test/controllers/subscriber_controller_test.exs
@@ -1,0 +1,13 @@
+defmodule Gotv.SubscriberControllerTest do
+  use Gotv.ConnCase
+
+  alias Gotv.Subscriber
+  @valid_attrs %{email_address: "jimmy@zeppelin.com", first_name: "Jimmy",
+                 last_name: "Page"}
+
+  test "creates resource and redirects when data is valid", %{conn: conn} do
+    conn = post conn, subscriber_path(conn, :create), subscriber: @valid_attrs
+    assert redirected_to(conn) == page_path(conn, :index)
+    assert Repo.get_by(Subscriber, @valid_attrs)
+  end
+end

--- a/test/controllers/subscriber_controller_test.exs
+++ b/test/controllers/subscriber_controller_test.exs
@@ -10,4 +10,9 @@ defmodule Gotv.SubscriberControllerTest do
     assert redirected_to(conn) == page_path(conn, :index)
     assert Repo.get_by(Subscriber, @valid_attrs)
   end
+
+  test "does not create resource and renders errors when data is invalid", %{conn: conn} do
+    conn = post conn, subscriber_path(conn, :create), subscriber: %{email_address: ""}
+    assert html_response(conn, 200) =~ "Oops, something went wrong!"
+  end
 end

--- a/test/models/subscriber_test.exs
+++ b/test/models/subscriber_test.exs
@@ -18,4 +18,12 @@ defmodule Gotv.SubscriberTest do
     assert changeset.errors[:email_address] ==
       {"can't be blank", [validation: :required]}
   end
+
+  test "email address format must be valid" do
+    changeset = Subscriber.changeset(%Subscriber{}, %{email_address: "jimmy@test"})
+
+    refute changeset.valid?
+    assert changeset.errors[:email_address] ==
+      {"has invalid format", [validation: :format]}
+  end
 end

--- a/test/models/subscriber_test.exs
+++ b/test/models/subscriber_test.exs
@@ -1,0 +1,21 @@
+defmodule Gotv.SubscriberTest do
+  use Gotv.ModelCase
+
+  alias Gotv.Subscriber
+
+  @valid_attrs %{email_address: "jimmy@zeppelin.com"}
+
+  test "changeset with valid attributes" do
+    changeset = Subscriber.changeset(%Subscriber{}, @valid_attrs)
+
+    assert changeset.valid?
+  end
+
+  test "email address is required" do
+    changeset = Subscriber.changeset(%Subscriber{}, %{email_address: ""})
+
+    refute changeset.valid?
+    assert changeset.errors[:email_address] ==
+      {"can't be blank", [validation: :required]}
+  end
+end

--- a/web/controllers/page_controller.ex
+++ b/web/controllers/page_controller.ex
@@ -1,7 +1,10 @@
 defmodule Gotv.PageController do
   use Gotv.Web, :controller
 
+  alias Gotv.Subscriber
+
   def index(conn, _params) do
-    render conn, "index.html"
+    changeset = Subscriber.changeset(%Subscriber{})
+    render conn, "index.html", changeset: changeset
   end
 end

--- a/web/controllers/subscriber_controller.ex
+++ b/web/controllers/subscriber_controller.ex
@@ -5,7 +5,13 @@ defmodule Gotv.SubscriberController do
 
   def create(conn, %{"subscriber" => subscriber_params}) do
     changeset = Subscriber.changeset(%Subscriber{}, subscriber_params)
-    Repo.insert(changeset)
-    conn |> redirect(to: page_path(conn, :index))
+    case Repo.insert(changeset) do
+      {:ok, _subscriber} ->
+        conn
+        |> put_flash(:info, "You have subscribed successfully and you will receive email reminders to vote!")
+        |> redirect(to: page_path(conn, :index))
+      {:error, changeset} ->
+        render(conn, Gotv.PageView, "index.html", changeset: changeset)
+    end
   end
 end

--- a/web/controllers/subscriber_controller.ex
+++ b/web/controllers/subscriber_controller.ex
@@ -1,0 +1,11 @@
+defmodule Gotv.SubscriberController do
+  use Gotv.Web, :controller
+
+  alias Gotv.Subscriber
+
+  def create(conn, %{"subscriber" => subscriber_params}) do
+    changeset = Subscriber.changeset(%Subscriber{}, subscriber_params)
+    Repo.insert(changeset)
+    conn |> redirect(to: page_path(conn, :index))
+  end
+end

--- a/web/models/subscriber.ex
+++ b/web/models/subscriber.ex
@@ -1,0 +1,20 @@
+defmodule Gotv.Subscriber do
+  use Gotv.Web, :model
+
+  schema "subscribers" do
+    field :first_name, :string
+    field :last_name, :string
+    field :email_address, :string
+
+    timestamps()
+  end
+
+  @doc """
+  Builds a changeset based on the `struct` and `params`.
+  """
+  def changeset(struct, params \\ %{}) do
+    struct
+    |> cast(params, [:first_name, :last_name, :email_address])
+    |> validate_required([:email_address])
+  end
+end

--- a/web/models/subscriber.ex
+++ b/web/models/subscriber.ex
@@ -16,5 +16,6 @@ defmodule Gotv.Subscriber do
     struct
     |> cast(params, [:first_name, :last_name, :email_address])
     |> validate_required([:email_address])
+    |> validate_format(:email_address, ~r/@[a-z\d\-.]+\.[a-z]+\z/i)
   end
 end

--- a/web/router.ex
+++ b/web/router.ex
@@ -17,6 +17,8 @@ defmodule Gotv.Router do
     pipe_through :browser # Use the default browser stack
 
     get "/", PageController, :index
+
+    resources "/subscribers", SubscriberController, only: [:create]
   end
 
   # Other scopes may use custom stacks.

--- a/web/templates/page/index.html.eex
+++ b/web/templates/page/index.html.eex
@@ -1,0 +1,19 @@
+<h2>Get out the vote!</h2>
+
+<%= form_for @changeset, subscriber_path(@conn, :create), fn f -> %>
+  <%= if @changeset.action do %>
+    <div class="alert alert-danger">
+      <p>Oops, something went wrong! Please check the errors below.</p>
+    </div>
+  <% end %>
+
+  <div class="form-group">
+    <%= label f, :email_address, class: "control-label" %>
+    <%= text_input f, :email_address, type: "email", class: "form-control" %>
+    <%= error_tag f, :email_address %>
+  </div>
+
+  <div class="form-group">
+    <%= submit "Submit", class: "btn btn-primary" %>
+  </div>
+<% end %>


### PR DESCRIPTION
Saves email addresses in the database table `subscribers`. Email address is required and needs a valid format in order to save. Optional first name and last name fields are also available.